### PR TITLE
Update deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var concat = require('concat-stream');
 var ffmpeg = require('fluent-ffmpeg');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var path = require('path');
 var through2 = require('through2');
 
@@ -16,7 +16,7 @@ module.exports = function (format, handler) {
 
   if (!format && !handler) {
     var msg = 'must include a file format, an ffmpeg handler or both';
-    throw new gutil.PluginError('gulp-fluent-ffmpeg', msg);
+    throw new PluginError('gulp-fluent-ffmpeg', msg);
   }
 
   return through2.obj(function (file, enc, callback) {
@@ -34,7 +34,9 @@ module.exports = function (format, handler) {
       if (format) cmd.format(format);
       cmd.input(input);
       cmd.output(output);
-      cmd.on('error', self.emit.bind(this, 'error'));
+      cmd.on('error', function() {
+        self.emit.apply(self, ['error'].concat(Array.prototype.slice.call(arguments)))
+      });
       cmd.run();
     }
 

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
     "url": "https://github.com/psirenny/gulp-fluent-ffmpeg/issues"
   },
   "dependencies": {
-    "concat-stream": "^1.4.8",
-    "fluent-ffmpeg": "^2.0.1",
-    "gulp-util": "^3.0.4",
-    "through2": "^0.6.5"
+    "concat-stream": "^2.0.0",
+    "fluent-ffmpeg": "^2.1.2",
+    "plugin-error": "^1.0.1",
+    "through2": "^3.0.1"
   },
   "description": "A fluent ffmpeg plugin for gulp.",
   "devDependencies": {
-    "stream-equal": "^0.1.5",
-    "tape": "^4.0.0",
-    "vinyl": "^0.4.6"
+    "stream-equal": "^1.1.1",
+    "tape": "^4.10.2",
+    "vinyl": "^2.2.0"
   },
   "homepage": "https://github.com/psirenny/gulp-fluent-ffmpeg#readme",
   "keywords": [


### PR DESCRIPTION
Hi!

Don't know if you're still interested in this project, but I've updated the dependencies and changed a line of code that would break in my case. (Mac OS, node v12.1.0)

I would get an error like this:

`TypeError: this.listenerCount is not a function
    at EventEmitter.emit (domain.js:465:32)
    at FfmpegCommand.emit (events.js:196:13)
    at FfmpegCommand.EventEmitter.emit (domain.js:471:20)
    at emitEnd (**/node_modules/fluent-ffmpeg/lib/processor.js:424:16)
    at endCB (**/node_modules/fluent-ffmpeg/lib/processor.js:544:13)
    at handleExit (**/node_modules/fluent-ffmpeg/lib/processor.js:170:11)
    at ChildProcess.<anonymous> (**/node_modules/fluent-ffmpeg/lib/processor.js:182:11)
    at ChildProcess.emit (events.js:196:13)
    at ChildProcess.EventEmitter.emit (domain.js:494:23)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:256:12)`

Also removed gutils and replaced it with the suggested replacement, because it is deprecated.

Don't worry if you are not actively maintaining, just thought I would share this in case you are interested.

Kind regards,

Davey.